### PR TITLE
Add VGA Text Buffer Writer Implementation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,8 +9,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "365861702868e2a37b4247aaecc7bd8f4389baec8d025497ad8ba7ff37ee9440"
 
 [[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+dependencies = [
+ "spin 0.9.8",
+]
+
+[[package]]
 name = "rust_os"
 version = "0.1.0"
 dependencies = [
  "bootloader",
+ "lazy_static",
+ "spin 0.5.2",
+ "volatile",
 ]
+
+[[package]]
+name = "spin"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
+
+[[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+
+[[package]]
+name = "volatile"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6b06ad3ed06fef1713569d547cdbdb439eafed76341820fb0e0344f29a41945"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,12 @@ edition = "2018"
 
 [dependencies]
 bootloader = "0.9"
+volatile = "0.2.6"
+spin = "0.5.2"
+
+[dependencies.lazy_static]
+version = "1.0"
+features = ["spin_no_std"]
 
 [profile.dev]
 panic = "abort"

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # **InfinityOS**
 
+>[!IMPORTANT]
+>InfinityOS is still in very early development, is being developed on and off, and is currently not ready for normal usage.
+
 Welcome to **InfinityOS**, an experimental operating system written in Rust. This project explores the boundaries of Rust in systems programming and serves as a platform for learning and innovation.
 
 ## **Features**

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,26 +1,22 @@
 #![no_std]
 #![no_main]
 
+mod vga_buffer;
+
 use core::panic::PanicInfo;
 
 static HELLO: &[u8] = b"Hello World!";
 
 #[no_mangle]
 pub extern "C" fn _start() -> ! {
-    let vga_buffer = 0xb8000 as *mut u8;
-
-    for (i, &byte) in HELLO.iter().enumerate() {
-        unsafe {
-            *vga_buffer.offset(i as isize * 2) = byte;
-            *vga_buffer.offset(i as isize * 2 + 1) = 0xb;
-        }
-    }
+    println!("Hello World{}", "!");
 
     loop {}
 }
 
 // This function is called on panic.
 #[panic_handler]
-fn panic(_info: &PanicInfo) -> ! {
+fn panic(info: &PanicInfo) -> ! {
+    println!("{}", info);
     loop {}
 }

--- a/src/vga_buffer.rs
+++ b/src/vga_buffer.rs
@@ -1,0 +1,170 @@
+use core::fmt;
+use lazy_static::lazy_static;
+use spin::Mutex;
+use volatile::Volatile;
+
+lazy_static! {
+    // A global `Writer` instance that can be used for printing to the VGA text buffer.
+    // Used by the `print!` and `println!` macros.
+    pub static ref WRITER: Mutex<Writer> = Mutex::new(Writer {
+        column_position: 0,
+        color_code: ColorCode::new(Color::Yellow, Color::Black),
+        buffer: unsafe { &mut *(0xb8000 as *mut Buffer) },
+    });
+}
+
+// The standard color palette in VGA text mode.
+#[allow(dead_code)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u8)]
+pub enum Color {
+    Black = 0,
+    Blue = 1,
+    Green = 2,
+    Cyan = 3,
+    Red = 4,
+    Magenta = 5,
+    Brown = 6,
+    LightGray = 7,
+    DarkGray = 8,
+    LightBlue = 9,
+    LightGreen = 10,
+    LightCyan = 11,
+    LightRed = 12,
+    Pink = 13,
+    Yellow = 14,
+    White = 15,
+}
+
+// A combination of a foreground and a background color.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(transparent)]
+struct ColorCode(u8);
+
+impl ColorCode {
+    // Create a new `ColorCode` with the given foreground and background colors.
+    fn new(foreground: Color, background: Color) -> ColorCode {
+        ColorCode((background as u8) << 4 | (foreground as u8))
+    }
+}
+
+// A screen character in the VGA text buffer, consisting of an ASCII character and a `ColorCode`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(C)]
+struct ScreenChar {
+    ascii_character: u8,
+    color_code: ColorCode,
+}
+
+// The height of the text buffer (normally 25 lines).
+const BUFFER_HEIGHT: usize = 25;
+// The width of the text buffer (normally 80 columns).
+const BUFFER_WIDTH: usize = 80;
+
+// A structure representing the VGA text buffer.
+#[repr(transparent)]
+struct Buffer {
+    chars: [[Volatile<ScreenChar>; BUFFER_WIDTH]; BUFFER_HEIGHT],
+}
+
+// A writer type that allows writing ASCII bytes and strings to an underlying `Buffer`.
+//
+// Wraps lines at `BUFFER_WIDTH`. Supports newline characters and implements the
+// `core::fmt::Write` trait.
+pub struct Writer {
+    column_position: usize,
+    color_code: ColorCode,
+    buffer: &'static mut Buffer,
+}
+
+impl Writer {
+    // Writes an ASCII byte to the buffer.
+    //
+    // Wraps lines at `BUFFER_WIDTH`. Supports the `\n` newline character.
+    pub fn write_byte(&mut self, byte: u8) {
+        match byte {
+            b'\n' => self.new_line(),
+            byte => {
+                if self.column_position >= BUFFER_WIDTH {
+                    self.new_line();
+                }
+
+                let row = BUFFER_HEIGHT - 1;
+                let col = self.column_position;
+
+                let color_code = self.color_code;
+                self.buffer.chars[row][col].write(ScreenChar {
+                    ascii_character: byte,
+                    color_code,
+                });
+                self.column_position += 1;
+            }
+        }
+    }
+
+    // Writes the given ASCII string to the buffer.
+    //
+    // Wraps lines at `BUFFER_WIDTH`. Supports the `\n` newline character. Does **not**
+    // support strings with non-ASCII characters, since they can't be printed in the VGA text
+    // mode.
+    fn write_string(&mut self, s: &str) {
+        for byte in s.bytes() {
+            match byte {
+                // printable ASCII byte or newline
+                0x20..=0x7e | b'\n' => self.write_byte(byte),
+                // not part of printable ASCII range
+                _ => self.write_byte(0xfe),
+            }
+        }
+    }
+
+    // Shifts all lines one line up and clears the last row.
+    fn new_line(&mut self) {
+        for row in 1..BUFFER_HEIGHT {
+            for col in 0..BUFFER_WIDTH {
+                let character = self.buffer.chars[row][col].read();
+                self.buffer.chars[row - 1][col].write(character);
+            }
+        }
+        self.clear_row(BUFFER_HEIGHT - 1);
+        self.column_position = 0;
+    }
+
+    // Clears a row by overwriting it with blank characters.
+    fn clear_row(&mut self, row: usize) {
+        let blank = ScreenChar {
+            ascii_character: b' ',
+            color_code: self.color_code,
+        };
+        for col in 0..BUFFER_WIDTH {
+            self.buffer.chars[row][col].write(blank);
+        }
+    }
+}
+
+impl fmt::Write for Writer {
+    fn write_str(&mut self, s: &str) -> fmt::Result {
+        self.write_string(s);
+        Ok(())
+    }
+}
+
+// Like the `print!` macro in the standard library, but prints to the VGA text buffer.
+#[macro_export]
+macro_rules! print {
+    ($($arg:tt)*) => ($crate::vga_buffer::_print(format_args!($($arg)*)));
+}
+
+// Like the `println!` macro in the standard library, but prints to the VGA text buffer.
+#[macro_export]
+macro_rules! println {
+    () => ($crate::print!("\n"));
+    ($($arg:tt)*) => ($crate::print!("{}\n", format_args!($($arg)*)));
+}
+
+// Prints the given formatted string to the VGA text buffer through the global `WRITER` instance.
+#[doc(hidden)]
+pub fn _print(args: fmt::Arguments) {
+    use core::fmt::Write;
+    WRITER.lock().write_fmt(args).unwrap();
+}


### PR DESCRIPTION
## Summary
This pull request introduces a low-level system for writing text to the VGA text buffer, enabling formatted text output in environments like an operating system kernel. The implementation includes a global writer instance, custom data structures, and macros for convenient printing.

## Features
- **Global Writer**: A thread-safe, lazily initialized `Writer` instance for managing text output.
- **Color Management**: Support for VGA's 16 standard colors, with customizable foreground and background combinations.
- **Screen Characters and Buffer**: Structures to represent individual characters and the VGA text buffer, ensuring proper memory handling.
- **Writer Functionality**:
  - Writing individual ASCII bytes or strings to the screen.
  - Automatic line wrapping and scrolling.
  - Clearing rows for clean output management.
- **Formatting Integration**: Compatibility with Rust's formatting macros (`write!`, `writeln!`).
- **Macros**: Custom `print!` and `println!` macros for seamless text output.

## Why This Is Needed
This feature is critical for enabling low-level text output without relying on external libraries or higher-level abstractions. It provides a foundational mechanism for debugging, logging, and user interaction in a bare-metal environment.

## Testing
- Verified output to the VGA text buffer in a simulated environment.
- Tested handling of long strings, line wrapping, and scrolling behavior.
- Ensured proper functionality of custom macros and formatting integration.

## Future Improvements
- Extend support for additional VGA modes or higher resolutions.
- Add support for non-ASCII character sets if needed.
- Explore optimizations for rendering efficiency.

## Impact
This addition lays the groundwork for further development of text-based user interfaces and debugging tools in the kernel. It provides a reliable and efficient mechanism for interacting with the VGA hardware.
